### PR TITLE
Update Toyota Mirai generations: Verified two-generation structure from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Toyota Mirai
+
+This repository contains signal set configurations for the Toyota Mirai, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Toyota Mirai.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Toyota_Mirai"
+
 generations:
   - name: "First Generation (JPD10)"
     start_year: 2014


### PR DESCRIPTION
## Summary
- First Generation (JPD10): 2014-2020 - hydrogen fuel cell pioneer
- Second Generation (JPD20): 2020-present - TNGA-L platform, rear-wheel drive
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template